### PR TITLE
Prevent EventForm from defaulting sport selection

### DIFF
--- a/src/app/events/[id]/schedule/components/EventForm.tsx
+++ b/src/app/events/[id]/schedule/components/EventForm.tsx
@@ -1109,18 +1109,19 @@ const EventForm: React.FC<EventFormProps> = ({
                 if (selected && (!prev.sportConfig || prev.sportConfig.$id !== selected.$id)) {
                     return { ...prev, sportConfig: selected };
                 }
+                if (!selected && prev.sportConfig) {
+                    return { ...prev, sportConfig: null };
+                }
                 return prev;
             }
-            if (!isEditMode && sports.length > 0) {
-                const fallback = sports[0];
-                if (prev.sportId === fallback.$id && prev.sportConfig?.$id === fallback.$id) {
-                    return prev;
-                }
-                return { ...prev, sportId: fallback.$id, sportConfig: fallback };
+
+            if (prev.sportConfig) {
+                return { ...prev, sportConfig: null };
             }
+
             return prev;
         });
-    }, [sportsLoading, sports, sportsById, isEditMode]);
+    }, [sportsLoading, sportsById]);
 
     useEffect(() => {
         const requiresSets = Boolean(eventData.sportConfig?.usePointsPerSetWin);


### PR DESCRIPTION
## Summary
- stop EventForm from auto-selecting the first sport when none is chosen
- keep sport configuration in sync with the user's selection or clear it when no sport is set

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c5da15e5c832ebf15d8ccccb7301a)